### PR TITLE
feat: support building under Docker

### DIFF
--- a/build_netlify.sh
+++ b/build_netlify.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+set -x
+
+mkdir -p ".yarn" ".yarn_cache"
+yarn --global-folder "$(pwd)/.yarn" --cache-folder "$(pwd)/.yarn_cache"
+yarn bootstrap
+yarn build

--- a/docker_build_netlify-cms.sh
+++ b/docker_build_netlify-cms.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Exit on errors
+set -e
+set -x
+
+# Variables
+DOCKER_SOURCE_IMAGE="node"
+DOCKER_IMAGE_VERSION="13.1.0-stretch-slim"
+HOSTNAME="$(hostname)"
+USER="$(id -u)"
+GROUP="$(id -g)"
+CURRENT_DIR="$(pwd)"
+DOCKER_WORKDIR="${HOME}"
+
+docker run\
+ --cap-drop=all\
+ --memory=4GB\
+ --rm\
+ -i\
+ -v "${CURRENT_DIR}":"${DOCKER_WORKDIR}"\
+ -v /etc/group:/etc/group:ro\
+ -v /etc/passwd:/etc/passwd:ro\
+ -u "${USER}":"${GROUP}"\
+ -w "${DOCKER_WORKDIR}"\
+ --hostname="${HOSTNAME}"-netlify-builder-13-1-0\
+ --name=netlify_builder\
+ "${DOCKER_SOURCE_IMAGE}":"${DOCKER_IMAGE_VERSION}"\
+ /bin/bash -c "${DOCKER_WORKDIR}/build_netlify.sh"


### PR DESCRIPTION
Support building `netlify-cms` under Docker. Removes requirement to install prerequisites directly on build machine.